### PR TITLE
Add search and fetch tools for incidents

### DIFF
--- a/topdesk_mcp/tests/conftest.py
+++ b/topdesk_mcp/tests/conftest.py
@@ -1,0 +1,77 @@
+"""Pytest configuration for the topdesk_mcp test suite."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+if "requests" not in sys.modules:  # pragma: no cover - testing support only
+    stub = ModuleType("requests")
+
+    def _not_implemented(*args, **kwargs):
+        raise NotImplementedError("The real 'requests' library is not available in this environment.")
+
+    stub.get = _not_implemented
+    stub.post = _not_implemented
+    stub.put = _not_implemented
+    stub.delete = _not_implemented
+    stub.patch = _not_implemented
+    stub.Response = object
+    stub.exceptions = SimpleNamespace(RequestException=Exception)
+
+    sys.modules["requests"] = stub
+
+
+if "markitdown" not in sys.modules:  # pragma: no cover - testing support only
+    markitdown_stub = ModuleType("markitdown")
+
+    class MarkItDown:  # pylint: disable=too-few-public-methods
+        def __init__(self, *args, **kwargs):  # noqa: D401 - simple stub
+            """Stubbed MarkItDown initialiser."""
+
+        def convert(self, *args, **kwargs):  # pragma: no cover - placeholder
+            raise NotImplementedError("Document conversion is unavailable in the test environment.")
+
+    markitdown_stub.MarkItDown = MarkItDown
+    sys.modules["markitdown"] = markitdown_stub
+
+
+if "urllib3" not in sys.modules:  # pragma: no cover - testing support only
+    urllib3_stub = ModuleType("urllib3")
+
+    class _Exceptions(SimpleNamespace):
+        InsecureRequestWarning = Warning
+
+    def disable_warnings(*args, **kwargs):  # noqa: D401 - helper stub
+        """Stubbed disable_warnings function."""
+
+    urllib3_stub.exceptions = _Exceptions()
+    urllib3_stub.disable_warnings = disable_warnings
+
+    sys.modules["urllib3"] = urllib3_stub
+
+
+if "fastmcp" not in sys.modules:  # pragma: no cover - testing support only
+    fastmcp_stub = ModuleType("fastmcp")
+
+    class FastMCP:  # pylint: disable=too-few-public-methods
+        def __init__(self, name):
+            self.name = name
+
+        def tool(self, *_args, **_kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fastmcp_stub.FastMCP = FastMCP
+    sys.modules["fastmcp"] = fastmcp_stub
+
+
+if "dotenv" not in sys.modules:  # pragma: no cover - testing support only
+    dotenv_stub = ModuleType("dotenv")
+
+    def load_dotenv(*_args, **_kwargs):  # noqa: D401 - simple stub
+        """Stub implementation of load_dotenv."""
+
+    dotenv_stub.load_dotenv = load_dotenv
+    sys.modules["dotenv"] = dotenv_stub

--- a/topdesk_mcp/tests/test_main_tools.py
+++ b/topdesk_mcp/tests/test_main_tools.py
@@ -1,0 +1,99 @@
+import importlib
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.fixture
+def main_module(monkeypatch):
+    monkeypatch.setenv("TOPDESK_URL", "https://example.topdesk.net")
+    monkeypatch.setenv("TOPDESK_USERNAME", "user")
+    monkeypatch.setenv("TOPDESK_PASSWORD", "token")
+
+    module_name = "topdesk_mcp.main"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    mock_client = Mock()
+    with patch("topdesk_mcp._topdesk_sdk.connect", return_value=mock_client):
+        module = importlib.import_module(module_name)
+
+    yield module, mock_client
+
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+
+def test_search_uses_title_in_fiql(main_module):
+    module, mock_client = main_module
+    mock_client.incident.get_list.return_value = [
+        {
+            "id": "123",
+            "number": "I-0001",
+            "briefDescription": "Printer offline",
+            "processingStatus": {"name": "In Progress"},
+        },
+        {
+            "id": "456",
+            "number": "I-0002",
+            "briefDescription": "Printer out of ink",
+            "processingStatus": None,
+        },
+    ]
+
+    results = module.search("Printer", max_results=1)
+
+    mock_client.incident.get_list.assert_called_once_with(query="briefDescription==*Printer*")
+    assert results == [
+        {
+            "id": "123",
+            "number": "I-0001",
+            "title": "Printer offline",
+            "processingStatus": "In Progress",
+        }
+    ]
+
+
+def test_search_normalises_and_escapes_title(main_module):
+    module, mock_client = main_module
+    mock_client.incident.get_list.return_value = []
+
+    module.search('  "Test"   incident  ')
+
+    expected_query = 'briefDescription==*\\"Test\\" incident*'
+    mock_client.incident.get_list.assert_called_once_with(query=expected_query)
+
+
+def test_search_rejects_empty_title(main_module):
+    module, _ = main_module
+
+    with pytest.raises(ValueError):
+        module.search("   ")
+
+
+def test_fetch_returns_concise_by_default(main_module):
+    module, mock_client = main_module
+    mock_client.incident.get_concise.return_value = {"id": "abc"}
+
+    result = module.fetch("abc")
+
+    mock_client.incident.get_concise.assert_called_once_with(incident="abc")
+    assert result == {"id": "abc"}
+
+
+def test_fetch_can_return_full_incident(main_module):
+    module, mock_client = main_module
+    mock_client.incident.get.return_value = {"id": "abc", "details": "full"}
+
+    result = module.fetch("abc", concise=False)
+
+    mock_client.incident.get.assert_called_once_with(incident="abc")
+    assert result == {"id": "abc", "details": "full"}
+
+
+def test_fetch_requires_identifier(main_module):
+    module, _ = main_module
+
+    with pytest.raises(ValueError):
+        module.fetch(" ")


### PR DESCRIPTION
## Summary
- implement Codex-aware `search` tool that looks up incidents by title and returns identifiers and key metadata
- validate `fetch` requests and reuse concise or full incident retrieval accordingly
- add focused unit tests with lightweight stubs for optional dependencies to exercise the new tools

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68cc09f8a9948324b94e9f0110b7f6f6